### PR TITLE
Implement quantity override when cloning quote

### DIFF
--- a/widgetsComputed/copyquote.js
+++ b/widgetsComputed/copyquote.js
@@ -31,6 +31,7 @@ return async function (rowData) {
         let newLineObj = copyObjectWithoutExcludedProps(line);
         newLineObj.name = 'C' + line.name; // Prefix the cloned quote line's name with "C"
         newLineObj.quote = newQuoteId; // Linking the new line to the cloned quote
+        newLineObj.qtytoMfg = 2; // Set quantity to 2 on cloned quote line
 
         let newLineId = await $dgAddRow('quoteLines', newLineObj); // Add the cloned quote line
 


### PR DESCRIPTION
## Summary
- ensure cloned quote lines set quantity to 2

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68443a9534848320bf516c33a15942fd